### PR TITLE
Update to HumHub 1.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ENV HUMHUB_VERSION=v1.2.3
+ENV HUMHUB_VERSION=v1.2.4
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This container provides a quick, flexible and lightwight way to set-up a proof-o
 ## Versions
 
 * `latest`:  unstable master build (use with caution! might be unstable)
-* `1.2.2`: latest stable release (recommended)
+* `1.2.4`: latest stable release (recommended)
 * `1.0.1`: latest 1.0.x release (not recommended)
 * `experimental`: test build (testing only) 
 


### PR DESCRIPTION
Update to HumHub 1.2.4

Before merging this, it would make sense to have an image for 1.2.3 tagged.