### PR TITLE
upgrade to use HumHub 1.3.2

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,13 @@ if [ -f "/var/www/localhost/htdocs/protected/config/dynamic.php" ]; then
     php yii search/rebuild
     cp -v /usr/src/humhub/.version /var/www/localhost/htdocs/protected/config/.version
   fi
+
+  echo "Setting permissions..."
+  chown -R nginx:nginx /var/www/localhost/htdocs/uploads
+  chown -R nginx:nginx /var/www/localhost/htdocs/protected/modules
+  chown -R nginx:nginx /var/www/localhost/htdocs/protected/config
+  chown -R nginx:nginx /var/www/localhost/htdocs/protected/runtime
+
 else
   echo "No existing installation found!"
   echo "Installing source files..."

--- a/etc/crontabs/nginx
+++ b/etc/crontabs/nginx
@@ -1,2 +1,2 @@
-30 * * * * /var/www/localhost/htdocs/protected/yii cron/hourly >/dev/null 2>&1
-00 18 * * * /var/www/localhost/htdocs/protected/yii cron/daily >/dev/null 2>&1
+* * * * * /var/www/localhost/htdocs/protected/yii queue/run >/dev/null 2>&1
+* * * * * /var/www/localhost/htdocs/protected/yii cron/run >/dev/null 2>&1

--- a/etc/php-fpm.d/pool.conf
+++ b/etc/php-fpm.d/pool.conf
@@ -25,8 +25,8 @@ catch_workers_output = yes
 
 php_admin_value[memory_limit] = 512M
 php_admin_value[max_execution_time] = 60
-php_admin_value[upload_max_filesize] = 10M
-php_admin_value[post_max_size] = 10M
+php_admin_value[upload_max_filesize] = 128M
+php_admin_value[post_max_size] = 128M
 php_admin_flag[log_errors] = on
 php_admin_value[error_log] = '/proc/self/fd/2'
 php_admin_value[display_errors] = 'stderr'


### PR DESCRIPTION
Probably this isn't so useful. But here are the changes I did to your master to get it working with HumHub 1.3. I tried with HumHub 1.3.1 first and this composer thing didn't seem to put all dependencies together. I always had problems with some missing yii queue package. I eventually gave up on this and decided to just use the HumHub tarball, which already includes the dependencies. I didn't check whether HumHub 1.3.2 has the same issues.

As I see now, you already have a branch to support HumHub 1.3, so feel free to just close this pull request.