### PR TITLE
Fix creation of version file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
+ARG HUMHUB_VERSION=1.3.8
+
 FROM composer:1.7 as builder-composer
 
 FROM alpine:3.8 as builder
 
-ENV HUMHUB_VERSION=1.3.8
+ARG HUMHUB_VERSION
 
 RUN apk update
 RUN apk add --no-cache \
@@ -58,6 +60,8 @@ RUN rm -rf ./node_modules
 
 
 FROM alpine:3.8
+
+ARG HUMHUB_VERSION
 
 RUN apk add --no-cache \
     curl \


### PR DESCRIPTION
ENV vars and ARG are scoped per build-stage. A Workaround is a global ARG.

see https://github.com/moby/moby/issues/37345#issuecomment-400245466