### PR TITLE
Fix ARG declaration in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-ARG HUMHUB_VERSION=1.3.8
-
 FROM composer:1.7 as builder-composer
 
 FROM alpine:3.8 as builder
 
-ARG HUMHUB_VERSION
+ARG HUMHUB_VERSION=1.3.8
 
 RUN apk update
 RUN apk add --no-cache \
@@ -61,7 +59,7 @@ RUN rm -rf ./node_modules
 
 FROM alpine:3.8
 
-ARG HUMHUB_VERSION
+ARG HUMHUB_VERSION=1.3.8
 
 RUN apk add --no-cache \
     curl \


### PR DESCRIPTION
This does not work at all. There is/was an issue that every ARG is reset after a FROM command, but declaring it like that declares the variable to nothing.
The previous issue I mentioned that updates are not working is simply because of this, since the .version file is wrong, and it breaks down at the version comparison in the .sh script file, and none of the update scripts (DB, recalculating search indexes, etc.) are executed.
This is pretty uncomfortable to set it 2 times, if you have a better solution, let me know, I'll change the PR.