### PR TITLE
fix wrong rights of dynamic.php

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -77,6 +77,7 @@ else
 		fi
 		php yii installer/create-admin-account
 		chown -R nginx:nginx /var/www/localhost/htdocs/protected/runtime
+		chown nginx:nginx /var/www/localhost/htdocs/protected/config/dynamic.php
 	fi
 fi
 


### PR DESCRIPTION
If you set up the docker container with auto create on the script would add dynamic.php as root user. So you are not able so change settings in the administration menu. Fore me the issue is fixed by changing the owner of dynamic.php after the auto creation is done to the nginx user. 