### PR TITLE
Correct uploads mount in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ services:
       - "80:80"
     volumes:
       - "_data/config:/var/www/localhost/htdocs/protected/config"
-      - "_data/uploads:/var/www/localhost/htdocs/protected/uploads"
+      - "_data/protected_uploads:/var/www/localhost/htdocs/protected/uploads"
+      - "_data/uploads:/var/www/localhost/htdocs/uploads"
   db:
     image: mariadb:10.2
     environment:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ services:
       - "80:80"
     volumes:
       - "_data/config:/var/www/localhost/htdocs/protected/config"
-      - "_data/protected_uploads:/var/www/localhost/htdocs/protected/uploads"
       - "_data/uploads:/var/www/localhost/htdocs/uploads"
   db:
     image: mariadb:10.2


### PR DESCRIPTION
The Composer example in the readme shows a mount of the protected/uploads path. It should be the uploads path exposed in the Dockerfile.