### PR TITLE
✨ Add env var to set NGinx timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Following variables can be used to configure the embadded Nginx. The configfile 
 
 ```txt
 NGINX_CLIENT_MAX_BODY_SIZE [10m]
+NGINX_KEEPALIVE_TIMEOUT    [65]
 ```
 
 ## Contribution

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,7 @@ HUMHUB_LANG=${HUMHUB_LANG:-"en-US"}
 HUMHUB_DEBUG=${HUMHUB_DEBUG:-"false"}
 
 export NGINX_CLIENT_MAX_BODY_SIZE=${NGINX_CLIENT_MAX_BODY_SIZE:-10m}
+export NGINX_KEEPALIVE_TIMEOUT=${NGINX_KEEPALIVE_TIMEOUT:-65}
 
 wait_for_db() {
 	if [ "$WAIT_FOR_DB" == "false" ]; then
@@ -118,6 +119,7 @@ fi
 
 echo "Writing Nginx Config"
 envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE" < /etc/nginx/nginx.conf > /tmp/nginx.conf
+envsubst "\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
 cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 rm /tmp/nginx.conf
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -119,7 +119,10 @@ fi
 
 echo "Writing Nginx Config"
 envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE" < /etc/nginx/nginx.conf > /tmp/nginx.conf
-envsubst "\$NGINX_KEEPALIVE_TIMEOUT" < /tmp/nginx.conf > /tmp/nginx.conf
+cat /tmp/nginx.conf > /etc/nginx/nginx.conf
+rm /tmp/nginx.conf
+
+envsubst "\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
 cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 rm /tmp/nginx.conf
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -119,7 +119,7 @@ fi
 
 echo "Writing Nginx Config"
 envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE" < /etc/nginx/nginx.conf > /tmp/nginx.conf
-envsubst "\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
+envsubst "\$NGINX_KEEPALIVE_TIMEOUT" < /tmp/nginx.conf > /tmp/nginx.conf
 cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 rm /tmp/nginx.conf
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -118,11 +118,7 @@ else
 fi
 
 echo "Writing Nginx Config"
-envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE" < /etc/nginx/nginx.conf > /tmp/nginx.conf
-cat /tmp/nginx.conf > /etc/nginx/nginx.conf
-rm /tmp/nginx.conf
-
-envsubst "\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
+envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE,\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
 cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 rm /tmp/nginx.conf
 

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -28,7 +28,7 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    keepalive_timeout  65;
+    keepalive_timeout  ${NGINX_KEEPALIVE_TIMEOUT};
 
     #gzip  on;
     client_max_body_size ${NGINX_CLIENT_MAX_BODY_SIZE};


### PR DESCRIPTION
:sparkles: Add env var to set NGinx timeout to close #114

Signed-off-by: mathieu.brunot <mathieu.brunot@monogramm.io>