### PR TITLE
✨ Add env var to split containers

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -204,11 +204,7 @@ fi
 if [ "$NGINX_ENABLED" != "false" ]; then
 
 	echo "Writing Nginx Config"
-	envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE,\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
-	cat /tmp/nginx.conf > /etc/nginx/nginx.conf
-	rm /tmp/nginx.conf
-
-	envsubst "\$NGINX_CGI_PASS" < /etc/nginx/nginx.conf > /tmp/nginx.conf
+	envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE,\$NGINX_KEEPALIVE_TIMEOUT,\$NGINX_CGI_PASS" < /etc/nginx/nginx.conf > /tmp/nginx.conf
 	cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 	rm /tmp/nginx.conf
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -173,6 +173,12 @@ if [ "$HUMHUB_ENABLED" != "false" ]; then
 		if [ $SET_PJAX != "false" ]; then
 			sed -i -e "s/'enablePjax' => false/'enablePjax' => true/g" /var/www/localhost/htdocs/protected/config/common.php
 		fi
+
+		if [ -n "$HUMHUB_TRUSTED_HOSTS" ]; then
+			sed -i \
+				-e "s|'trustedHosts' => \['.*'\]|'trustedHosts' => ['$HUMHUB_TRUSTED_HOSTS']|g" \
+				/var/www/localhost/htdocs/protected/config/web.php
+		fi
 	else
 		echo "no installation config found or not installed"
 		INTEGRITY_CHECK="false"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,7 +50,9 @@ HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS=${HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS:-0
 export NGINX_ENABLED=${NGINX_ENABLED:-'true'}
 export NGINX_CLIENT_MAX_BODY_SIZE=${NGINX_CLIENT_MAX_BODY_SIZE:-10m}
 export NGINX_KEEPALIVE_TIMEOUT=${NGINX_KEEPALIVE_TIMEOUT:-65}
-export NGINX_CI_PASS=${NGINX_CI_PASS:-'unix:/run/php-fpm.sock'}
+export NGINX_CGI_PASS=${NGINX_CGI_PASS:-'unix:/run/php-fpm.sock'}
+
+export PHP_CGI_PASS=${PHP_CGI_PASS:-'/run/php-fpm.sock'}
 
 wait_for_db() {
 	if [ "$WAIT_FOR_DB" == "false" ]; then
@@ -67,6 +69,8 @@ wait_for_db() {
 echo "=="
 
 if [ "$HUMHUB_ENABLED" != "false" ]; then
+
+	sed -i -e "s|listen = .*|listen = ${PHP_CGI_PASS}|g" /etc/php-fpm.d/pool.conf
 
 	if [ -f "/var/www/localhost/htdocs/protected/config/dynamic.php" ]; then
 		echo "Existing installation found!"
@@ -204,7 +208,7 @@ if [ "$NGINX_ENABLED" != "false" ]; then
 	cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 	rm /tmp/nginx.conf
 
-	envsubst "\$NGINX_CI_PASS" < /etc/nginx/nginx.conf > /tmp/nginx.conf
+	envsubst "\$NGINX_CGI_PASS" < /etc/nginx/nginx.conf > /tmp/nginx.conf
 	cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 	rm /tmp/nginx.conf
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,6 +50,7 @@ HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS=${HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS:-0
 export NGINX_ENABLED=${NGINX_ENABLED:-'true'}
 export NGINX_CLIENT_MAX_BODY_SIZE=${NGINX_CLIENT_MAX_BODY_SIZE:-10m}
 export NGINX_KEEPALIVE_TIMEOUT=${NGINX_KEEPALIVE_TIMEOUT:-65}
+export NGINX_CI_PASS=${NGINX_CI_PASS:-'unix:/run/php-fpm.sock'}
 
 wait_for_db() {
 	if [ "$WAIT_FOR_DB" == "false" ]; then
@@ -200,6 +201,10 @@ if [ "$NGINX_ENABLED" != "false" ]; then
 
 	echo "Writing Nginx Config"
 	envsubst "\$NGINX_CLIENT_MAX_BODY_SIZE,\$NGINX_KEEPALIVE_TIMEOUT" < /etc/nginx/nginx.conf > /tmp/nginx.conf
+	cat /tmp/nginx.conf > /etc/nginx/nginx.conf
+	rm /tmp/nginx.conf
+
+	envsubst "\$NGINX_CI_PASS" < /etc/nginx/nginx.conf > /tmp/nginx.conf
 	cat /tmp/nginx.conf > /etc/nginx/nginx.conf
 	rm /tmp/nginx.conf
 

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -90,7 +90,7 @@ http {
             include fastcgi_params;
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fsn;
-            fastcgi_pass unix:/run/php-fpm.sock;
+            fastcgi_pass ${NGINX_CI_PASS};
         }
 
         location ~ /\.ht {

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -51,7 +51,7 @@ http {
             deny all;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_pass unix:/run/php-fpm.sock;
+            fastcgi_pass ${NGINX_CI_PASS};
         }
 
         location / {

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -51,7 +51,7 @@ http {
             deny all;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_pass ${NGINX_CI_PASS};
+            fastcgi_pass ${NGINX_CGI_PASS};
         }
 
         location / {
@@ -90,7 +90,7 @@ http {
             include fastcgi_params;
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fsn;
-            fastcgi_pass ${NGINX_CI_PASS};
+            fastcgi_pass ${NGINX_CGI_PASS};
         }
 
         location ~ /\.ht {


### PR DESCRIPTION
:sparkles: Add env var to split containers for #116

This can allow and admin to split each of the supervisor process into different containers, allowing more detailed docker / network configuration, without impacting the default behavior.