### PR TITLE
fixed imagemagick php extension

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-HUMHUB_DB_USER=humhub
 HUMHUB_DB_PASSWORD=you will never guess
+HUMHUB_DB_USER=humhub
 MARIADB_ROOT_PASSWORD=root pass

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ name: Lint Code Base
 #############################
 on:
   push:
-    branches-ignore: [master]
+    branches: [ master ]
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,4 +51,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false
+          LINTER_RULES_PATH: .
           DOCKERFILE_HADOLINT_FILE_NAME: .hadolint.yaml

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -49,3 +49,6 @@ jobs:
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_PHP_PHPSTAN: false
+          VALIDATE_PHP_PSALM: false
+          DOCKERFILE_HADOLINT_FILE_NAME: .hadolint.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apk add --no-cache \
     php7-json \
     php7-phar \
     php7-iconv \
-    php7-imagick \
+    php7-pecl-imagick \
     php7-openssl \
     php7-curl \
     php7-ctype \

--- a/README.md
+++ b/README.md
@@ -61,56 +61,56 @@ This container supports some further options which can be configured via environ
 
 ### `HUMHUB_DB_USER` & `HUMHUB_DB_PASSWORD`
 
-**default: `""` **
-  
+**default: `""`**
+
 This username and password will be used to connect to the database. Please do not set the HUMHUB_DB_PASSWORD without HUMHUB_DB_USER to avoid problems. If this is not set, the visual installer will show up at the first startup.
-  
+
 
 ### `HUMHUB_DB_NAME`
 
-**default: `humhub` **
+**default: `humhub`**
 
 Defines the name of the database where humhub is installed.
 
 ### `HUMHUB_DB_HOST`
 
-**default: `db` **
+**default: `db`**
 
 Defines the mysql/mariadb-database-host. If you use the `--link` argument please specify the name of the link as host or use `db` as linkname ( `--link <container>:db` ).
 
 ### `HUMHUB_AUTO_INSTALL`
 
-**default: `false` **
+**default: `false`**
 
 If this and `HUMHUB_DB_USER` are set an automated installation will run during the first startup. This feature utilities a hidden installer-feature used for integration testing ( [see code file](https://github.com/humhub/humhub/blob/master/protected/humhub/modules/installer/commands/InstallController.php) ).
 
 ### `HUMHUB_PROTO` & `HUMHUB_HOST`
 
-**default: `http` , `localhost` **
+**default: `http` , `localhost`**
 
 If these are defined during auto-installation, humhub will be installed and configured to use urls with those details. (i.e. If they are set as `HUMHUB_PROTO=https` , `HUMHUB_HOST=example.com` , humhub will be installed and configured so that the base url is `https://example.com/` . Leaving these as default will result in humhub being installed and configured to be at `http://localhost/` .
 
 ### `HUMHUB_ADMIN_LOGIN` & `HUMHUB_ADMIN_EMAIL` & `HUMHUB_ADMIN_PASSWORD`
 
-**default: `admin` , `humhub@example.com` , `test` **
+**default: `admin` , `humhub@example.com` , `test`**
 
 If these are defined during auto-installation, humhub admin will be created with those credentials.
 
 ### `INTEGRITY_CHECK`
 
-**default: `1` **
+**default: `1`**
 
 This can be set to `"false"` to disabled the startup integrity check. Use with caution!
 
 ### `WAIT_FOR_DB`
 
-**default: `1` **
+**default: `1`**
 
 Can be used to let the startup fail if the db host is unavailable. To disable this, set it to `"false"` . Can be useful if an external db-host is used, avoid when using a linked container.
 
 ### `SET_PJAX`
 
-**default: `1` **
+**default: `1`**
 
 PJAX is a jQuery plugin that uses ajax and pushState to deliver a fast browsing experience with real permalinks, page titles, and a working back button. ([ref](https://github.com/yiisoft/jquery-pjax)) This library is known to cause problems with some browsers during  installation. This container starts with PJAX disabled to improve the installation reliability. If this is set (default), PJAX is **enabled** during the **second** startup. Set this to `"false"` to permanently disable PJAX. Please note that changing this after container-creation has no effect on this behavior.
 
@@ -122,12 +122,12 @@ It is possible to configure HumHub email settings using the following environmen
 HUMHUB_MAILER_SYSTEM_EMAIL_ADDRESS    [noreply@example.com]
 HUMHUB_MAILER_SYSTEM_EMAIL_NAME       [HumHub]
 HUMHUB_MAILER_TRANSPORT_TYPE          [php]
-HUMHUB_MAILER_HOSTNAME                
-HUMHUB_MAILER_PORT                    
-HUMHUB_MAILER_USERNAME                
-HUMHUB_MAILER_PASSWORD                
-HUMHUB_MAILER_ENCRYPTION              
-HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS 
+HUMHUB_MAILER_HOSTNAME                []
+HUMHUB_MAILER_PORT                    []
+HUMHUB_MAILER_USERNAME                []
+HUMHUB_MAILER_PASSWORD                []
+HUMHUB_MAILER_ENCRYPTION              []
+HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS []
 ```
 
 ### LDAP Config
@@ -135,19 +135,19 @@ HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS
 It is possible to configure HumHub LDAP authentication settings using the following environment variables:
 
 ``` plaintext
-HUMHUB_LDAP_ENABLED             [0]
-HUMHUB_LDAP_HOSTNAME            
-HUMHUB_LDAP_PORT                
-HUMHUB_LDAP_ENCRYPTION          
-HUMHUB_LDAP_USERNAME            
-HUMHUB_LDAP_PASSWORD            
-HUMHUB_LDAP_BASE_DN             
-HUMHUB_LDAP_LOGIN_FILTER        
-HUMHUB_LDAP_USER_FILTER         
-HUMHUB_LDAP_USERNAME_ATTRIBUTE  
-HUMHUB_LDAP_EMAIL_ATTRIBUTE     
-HUMHUB_LDAP_ID_ATTRIBUTE        
-HUMHUB_LDAP_REFRESH_USERS       
+HUMHUB_LDAP_ENABLED            [0]
+HUMHUB_LDAP_HOSTNAME           []
+HUMHUB_LDAP_PORT               []
+HUMHUB_LDAP_ENCRYPTION         []
+HUMHUB_LDAP_USERNAME           []
+HUMHUB_LDAP_PASSWORD           []
+HUMHUB_LDAP_BASE_DN            []
+HUMHUB_LDAP_LOGIN_FILTER       []
+HUMHUB_LDAP_USER_FILTER        []
+HUMHUB_LDAP_USERNAME_ATTRIBUTE []
+HUMHUB_LDAP_EMAIL_ATTRIBUTE    []
+HUMHUB_LDAP_ID_ATTRIBUTE       []
+HUMHUB_LDAP_REFRESH_USERS      []
 ```
 
 ## PHP Config

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Alpine-based PHP-FPM and NGINX HumHub docker-container
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e2c25ed0c4ce479aa9a97be05d1d5b20)](https://app.codacy.com/app/mriedmann/humhub-docker?utm_source=github.com&utm_medium=referral&utm_content=mriedmann/humhub-docker&utm_campaign=Badge_Grade_Dashboard)
+
 ![Docker Image CI](https://github.com/mriedmann/humhub-docker/workflows/Docker%20Image%20CI/badge.svg)
 
 [HumHub](https://github.com/humhub/humhub) is a feature rich and highly flexible OpenSource Social Network Kit written in PHP.
@@ -8,10 +9,10 @@ This container provides a quick, flexible and lightweight way to set-up a proof-
 
 ## Versions
 
-* [![dockerimage badge (latest)](https://images.microbadger.com/badges/version/mriedmann/humhub:latest.svg)](https://microbadger.com/images/mriedmann/humhub:latest "Get your own version badge on microbadger.com") `latest`:  unstable master build (use with caution! might be unstable)
-* [![dockerimage badge (1.5.x)](https://images.microbadger.com/badges/version/mriedmann/humhub:1.5.2.svg)](https://microbadger.com/images/mriedmann/humhub:1.6.2 "Get your own version badge on microbadger.com") `1.5.2`: latest stable release (recommended)
-* [![dockerimage badge (1.6.x)](https://images.microbadger.com/badges/version/mriedmann/humhub:1.6.2.svg)](https://microbadger.com/images/mriedmann/humhub:1.6.2 "Get your own version badge on microbadger.com") `1.6.2`: latest beta release
-* [![dockerimage badge (experimental)](https://images.microbadger.com/badges/version/mriedmann/humhub:experimental.svg)](https://microbadger.com/images/mriedmann/humhub:experimental "Get your own version badge on microbadger.com") `experimental`: test build (testing only)
+* [![dockerimage badge (latest)](https://images.microbadger.com/badges/version/mriedmann/humhub:latest.svg)](https://microbadger.com/images/mriedmann/humhub:latest "Get your own version badge on microbadger.com") `latest` :  unstable master build (use with caution! might be unstable)
+* [![dockerimage badge (1.5.x)](https://images.microbadger.com/badges/version/mriedmann/humhub:1.5.2.svg)](https://microbadger.com/images/mriedmann/humhub:1.6.2 "Get your own version badge on microbadger.com") `1.5.2` : latest stable release (recommended)
+* [![dockerimage badge (1.6.x)](https://images.microbadger.com/badges/version/mriedmann/humhub:1.6.2.svg)](https://microbadger.com/images/mriedmann/humhub:1.6.2 "Get your own version badge on microbadger.com") `1.6.2` : latest beta release
+* [![dockerimage badge (experimental)](https://images.microbadger.com/badges/version/mriedmann/humhub:experimental.svg)](https://microbadger.com/images/mriedmann/humhub:experimental "Get your own version badge on microbadger.com") `experimental` : test build (testing only)
 
 ## Quickstart
 
@@ -29,18 +30,24 @@ No database integrated. For persistency look at the Compose-File example.
 
 ## Composer File Example
 
-```Dockerfile
+``` Dockerfile
 version: '3.1'
 services:
   humhub:
     build: .
     links:
+
       - "db:db"
+
     ports:
+
       - "80:80"
+
     volumes:
+
       - "_data/config:/var/www/localhost/htdocs/protected/config"
       - "_data/uploads:/var/www/localhost/htdocs/uploads"
+
   db:
     image: mariadb:10.2
     environment:
@@ -54,53 +61,56 @@ This container supports some further options which can be configured via environ
 
 ### `HUMHUB_DB_USER` & `HUMHUB_DB_PASSWORD`
 
-**default: `""`**
+**default: `""` **
   
 This username and password will be used to connect to the database. Please do not set the HUMHUB_DB_PASSWORD without HUMHUB_DB_USER to avoid problems. If this is not set, the visual installer will show up at the first startup.
   
+
 ### `HUMHUB_DB_NAME`
 
-**default: `humhub`**
+**default: `humhub` **
 
 Defines the name of the database where humhub is installed.
 
 ### `HUMHUB_DB_HOST`
 
-**default: `db`**
+**default: `db` **
 
-Defines the mysql/mariadb-database-host. If you use the `--link` argument please specify the name of the link as host or use `db` as linkname (`--link <container>:db`).
+Defines the mysql/mariadb-database-host. If you use the `--link` argument please specify the name of the link as host or use `db` as linkname ( `--link <container>:db` ).
 
 ### `HUMHUB_AUTO_INSTALL`
 
-**default: `false`**
+**default: `false` **
 
 If this and `HUMHUB_DB_USER` are set an automated installation will run during the first startup. This feature utilities a hidden installer-feature used for integration testing ( [see code file](https://github.com/humhub/humhub/blob/master/protected/humhub/modules/installer/commands/InstallController.php) ).
 
 ### `HUMHUB_PROTO` & `HUMHUB_HOST`
-**default: `http`, `localhost`**
 
-If these are defined during auto-installation, humhub will be installed and configured to use urls with those details. (i.e. If they are set as `HUMHUB_PROTO=https`, `HUMHUB_HOST=example.com`, humhub will be installed and configured so that the base url is `https://example.com/`. Leaving these as default will result in humhub being installed and configured to be at `http://localhost/`.
+**default: `http` , `localhost` **
+
+If these are defined during auto-installation, humhub will be installed and configured to use urls with those details. (i.e. If they are set as `HUMHUB_PROTO=https` , `HUMHUB_HOST=example.com` , humhub will be installed and configured so that the base url is `https://example.com/` . Leaving these as default will result in humhub being installed and configured to be at `http://localhost/` .
 
 ### `HUMHUB_ADMIN_LOGIN` & `HUMHUB_ADMIN_EMAIL` & `HUMHUB_ADMIN_PASSWORD`
-**default: `admin`, `humhub@example.com`, `test`**
+
+**default: `admin` , `humhub@example.com` , `test` **
 
 If these are defined during auto-installation, humhub admin will be created with those credentials.
 
 ### `INTEGRITY_CHECK`
 
-**default: `1`**
+**default: `1` **
 
 This can be set to `"false"` to disabled the startup integrity check. Use with caution!
 
 ### `WAIT_FOR_DB`
 
-**default: `1`**
+**default: `1` **
 
-Can be used to let the startup fail if the db host is unavailable. To disable this, set it to `"false"`. Can be useful if an external db-host is used, avoid when using a linked container.
+Can be used to let the startup fail if the db host is unavailable. To disable this, set it to `"false"` . Can be useful if an external db-host is used, avoid when using a linked container.
 
 ### `SET_PJAX`
 
-**default: `1`**
+**default: `1` **
 
 PJAX is a jQuery plugin that uses ajax and pushState to deliver a fast browsing experience with real permalinks, page titles, and a working back button. ([ref](https://github.com/yiisoft/jquery-pjax)) This library is known to cause problems with some browsers during  installation. This container starts with PJAX disabled to improve the installation reliability. If this is set (default), PJAX is **enabled** during the **second** startup. Set this to `"false"` to permanently disable PJAX. Please note that changing this after container-creation has no effect on this behavior.
 
@@ -108,7 +118,7 @@ PJAX is a jQuery plugin that uses ajax and pushState to deliver a fast browsing 
 
 It is possible to configure HumHub email settings using the following environment variables:
 
-```
+``` plaintext
 HUMHUB_MAILER_SYSTEM_EMAIL_ADDRESS    [noreply@example.com]
 HUMHUB_MAILER_SYSTEM_EMAIL_NAME       [HumHub]
 HUMHUB_MAILER_TRANSPORT_TYPE          [php]
@@ -120,12 +130,11 @@ HUMHUB_MAILER_ENCRYPTION
 HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS 
 ```
 
-
 ### LDAP Config
 
 It is possible to configure HumHub LDAP authentication settings using the following environment variables:
 
-```
+``` plaintext
 HUMHUB_LDAP_ENABLED             [0]
 HUMHUB_LDAP_HOSTNAME            
 HUMHUB_LDAP_PORT                
@@ -147,7 +156,7 @@ It is also possible to change some php-config-settings. This comes in handy if y
 
 Following environment variables can be used (default values in angle brackets):
 
-```txt
+``` plaintext
 PHP_POST_MAX_SIZE       [16M]
 PHP_UPLOAD_MAX_FILESIZE [10M]
 PHP_MAX_EXECUTION_TIME  [60]
@@ -159,7 +168,7 @@ PHP_TIMEZONE            [UTC]
 
 Following variables can be used to configure the embadded Nginx. The configfile gets rewritten on every container startup and is not persisted. Avoid changing it by hand.
 
-```txt
+``` plaintext
 NGINX_CLIENT_MAX_BODY_SIZE [10m]
 NGINX_KEEPALIVE_TIMEOUT    [65]
 ```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -57,7 +57,7 @@ wait_for_db() {
 		return 0
 	fi
 
-	until nc -z -v -w60 $HUMHUB_DB_HOST 3306; do
+	until nc -z -v -w60 "$HUMHUB_DB_HOST" 3306; do
 		echo "Waiting for database connection..."
 		# wait for 5 seconds before check again
 		sleep 5
@@ -210,8 +210,7 @@ fi
 
 if [ "$INTEGRITY_CHECK" != "false" ]; then
 	echo "validating ..."
-	php ./yii integrity/run
-	if [ $? -ne 0 ]; then
+	if ! php ./yii integrity/run; then
 		echo "validation failed!"
 		exit 1
 	fi
@@ -220,6 +219,8 @@ else
 fi
 
 echo "Writing Nginx Config"
+
+# shellcheck disable=SC2016
 envsubst '$NGINX_CLIENT_MAX_BODY_SIZE,$NGINX_KEEPALIVE_TIMEOUT' </etc/nginx/nginx.conf >/tmp/nginx.conf
 cat /tmp/nginx.conf >/etc/nginx/nginx.conf
 rm /tmp/nginx.conf

--- a/humhub/protected/config/common-factory.php
+++ b/humhub/protected/config/common-factory.php
@@ -16,7 +16,6 @@ $common = [
             'showScriptName' => false,
             'enablePrettyUrl' => true,
         ],
-        
     ]
 ];
 

--- a/humhub/protected/config/common-factory.php
+++ b/humhub/protected/config/common-factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file provides to overwrite the default HumHub / Yii configuration by your local common (Console and Web) environments
  * @see http://www.yiiframework.com/doc-2.0/guide-concept-configurations.html
@@ -7,7 +8,7 @@
  */
 
 $common = [
-	'params' => [
+    'params' => [
         'enablePjax' => false
     ],
     'components' => [
@@ -21,7 +22,7 @@ $common = [
 
 /**
  * Redis configuration.
- * 
+ *
  * @see https://docs.humhub.org/docs/admin/redis
  */
 if (!empty(getenv('HUMHUB_REDIS_HOSTNAME'))) {
@@ -57,4 +58,4 @@ if (!empty(getenv('HUMHUB_REDIS_HOSTNAME'))) {
 }
 
 // Print generated common config
-var_export ( $common );
+var_export($common);

--- a/humhub/protected/config/console.php
+++ b/humhub/protected/config/console.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * This file provides to overwrite the default HumHub / Yii configuration by your local Console environments
  * @see http://www.yiiframework.com/doc-2.0/guide-concept-configurations.html
  * @see http://docs.humhub.org/admin-installation-configuration.html
  * @see http://docs.humhub.org/dev-environment.html
  */
+
 return [
     'controllerMap' => [
         'installer' => 'humhub\modules\installer\commands\InstallController'

--- a/humhub/protected/config/web.php
+++ b/humhub/protected/config/web.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * This file provides to overwrite the default HumHub / Yii configuration by your local Web environments
  * @see http://www.yiiframework.com/doc-2.0/guide-concept-configurations.html
  * @see http://docs.humhub.org/admin-installation-configuration.html
  * @see http://docs.humhub.org/dev-environment.html
  */
+
 return [
     'components' => [
         'request' => [

--- a/humhub/protected/humhub/modules/installer/commands/InstallController.php
+++ b/humhub/protected/humhub/modules/installer/commands/InstallController.php
@@ -120,7 +120,14 @@ class InstallController extends Controller
         $admin_firstname = 'Sys',
         $admin_lastname = 'Admin'
     ) {
-        $user = $this->createUser($admin_user, $admin_email, $admin_pass, $admin_title, $admin_firstname, $admin_lastname);
+        $user = $this->createUser(
+            $admin_user,
+            $admin_email,
+            $admin_pass,
+            $admin_title,
+            $admin_firstname,
+            $admin_lastname
+        );
         $this->addUserToAdminGroup($user);
 
         return ExitCode::OK;
@@ -209,8 +216,14 @@ class InstallController extends Controller
     /**
      * Creates a new user account.
      */
-    private function createUser(string $username, string $email, string $pass, string $title, string $firstname, string $lastname): User
-    {
+    private function createUser(
+        string $username,
+        string $email,
+        string $pass,
+        string $title,
+        string $firstname,
+        string $lastname
+    ): User {
         $user = new User();
         $user->username = $username;
         $user->email = $email;

--- a/humhub/protected/humhub/modules/installer/commands/InstallController.php
+++ b/humhub/protected/humhub/modules/installer/commands/InstallController.php
@@ -22,13 +22,13 @@ use humhub\libs\DynamicConfig;
 
 /**
  * Console Install
- * 
+ *
  * Example usage:
  *   php yii installer/write-db-config "$HUMHUB_DB_HOST" "$HUMHUB_DB_NAME" "$HUMHUB_DB_USER" "$HUMHUB_DB_PASSWORD"
  *   php yii installer/install-db
  *   php yii installer/write-site-config "$HUMHUB_NAME" "$HUMHUB_EMAIL"
  *   php yii installer/create-admin-account
- * 
+ *
  * @author Luke
  * @author Michael Riedmann
  * @author Mathieu Brunot
@@ -53,11 +53,12 @@ class InstallController extends Controller
     }
 
     /**
-     * Tries to open a connection to given db. 
+     * Tries to open a connection to given db.
      * On success: Writes given settings to config-file and reloads it.
      * On failure: Throws exception
      */
-    public function actionWriteDbConfig($db_host, $db_name, $db_user, $db_pass) {
+    public function actionWriteDbConfig($db_host, $db_name, $db_user, $db_pass)
+    {
         $connectionString = "mysql:host=" . $db_host . ";dbname=" . $db_name;
         $dbConfig = [
             'class' => 'yii\db\Connection',
@@ -89,7 +90,7 @@ class InstallController extends Controller
         $this->stdout("Install DB:\n\n", Console::FG_YELLOW);
 
         $this->stdout("  * Checking Database Connection\n", Console::FG_YELLOW);
-        if(!$this->checkDBConnection()){
+        if (!$this->checkDBConnection()) {
             throw new Exception("Could not connect to DB!");
         }
 
@@ -111,9 +112,14 @@ class InstallController extends Controller
     /**
      * Creates a new user account and adds it to the admin-group
      */
-    public function actionCreateAdminAccount($admin_user='admin', $admin_email='humhub@example.com', $admin_pass='test',
-        $admin_title='System Administration', $admin_firstname='Sys', $admin_lastname='Admin')
-    {
+    public function actionCreateAdminAccount(
+        $admin_user = 'admin',
+        $admin_email = 'humhub@example.com',
+        $admin_pass = 'test',
+        $admin_title = 'System Administration',
+        $admin_firstname = 'Sys',
+        $admin_lastname = 'Admin'
+    ) {
         $user = $this->createUser($admin_user, $admin_email, $admin_pass, $admin_title, $admin_firstname, $admin_lastname);
         $this->addUserToAdminGroup($user);
 
@@ -123,7 +129,8 @@ class InstallController extends Controller
     /**
      * Writes essential site settings to config file and sets installed state
      */
-    public function actionWriteSiteConfig($site_name='HumHub', $site_email='humhub@example.com'){
+    public function actionWriteSiteConfig($site_name = 'HumHub', $site_email = 'humhub@example.com')
+    {
         $this->stdout("Install Site:\n\n", Console::FG_YELLOW);
         InitialData::bootstrap();
 
@@ -137,7 +144,8 @@ class InstallController extends Controller
         return ExitCode::OK;
     }
 
-    public function actionSetBaseUrl($base_url){
+    public function actionSetBaseUrl($base_url)
+    {
         $this->stdout("Setting base url", Console::FG_YELLOW);
         Yii::$app->settings->set('baseUrl', $base_url);
 
@@ -147,7 +155,8 @@ class InstallController extends Controller
     /**
      * Checks install status
      */
-    public function actionStatus(){
+    public function actionStatus()
+    {
         $config = DynamicConfig::load();
 
         if (!isset($config['params']['databaseInstalled']) || empty($config['params']['databaseInstalled'])) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<ruleset name="super-linter">
+    <description>The default coding standard for usage with GitHub Super-Linter. It just includes PSR12.</description>
+    <rule ref="PSR12">
+        <exclude name="Generic.Files.LineLength"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
The actual name of the php-extension package in alpine is `php7-pecl-imagick` not `php7-imagick` (at least in version 3.12). 