### PR TITLE
Feat ldap ssl

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -167,7 +167,7 @@ else
 
 		if [ "$HUMHUB_LDAP_CACERT" != "" ]; then
 			echo "Setting LDAP CACERT"
-			echo $HUMHUB_LDAP_CACERT > /etc/ssl/certs/cacert.crt
+			echo "$HUMHUB_LDAP_CACERT" > /etc/ssl/certs/cacert.crt
 			echo "TLS_CACERT  /etc/ssl/certs/cacert.crt" >> /etc/openldap/ldap.conf
 		fi
 		

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,6 +37,8 @@ HUMHUB_LDAP_USERNAME_ATTRIBUTE=${HUMHUB_LDAP_USERNAME_ATTRIBUTE}
 HUMHUB_LDAP_EMAIL_ATTRIBUTE=${HUMHUB_LDAP_EMAIL_ATTRIBUTE}
 HUMHUB_LDAP_ID_ATTRIBUTE=${HUMHUB_LDAP_ID_ATTRIBUTE}
 HUMHUB_LDAP_REFRESH_USERS=${HUMHUB_LDAP_REFRESH_USERS:-1}
+HUMHUB_LDAP_CACERT=${HUMHUB_LDAP_CACERT:""}
+HUMHUB_LDAP_SKIP_VERIFY=${HUMHUB_LDAP_SKIP_VERIFY:-0}
 
 # Mailer Config
 HUMHUB_MAILER_SYSTEM_EMAIL_ADDRESS=${HUMHUB_MAILER_SYSTEM_EMAIL_ADDRESS:-"noreply@example.com"}
@@ -158,6 +160,17 @@ else
 			php yii 'settings/set' 'ldap' 'refreshUsers' "${HUMHUB_LDAP_REFRESH_USERS}"
 		fi
 
+		if [ "$HUMHUB_LDAP_SKIP_VERIFY" != "0" ]; then
+			echo "Setting LDAP TLS SKIP VERIFY"
+			echo "TLS_REQCERT ALLOW" >> /etc/openldap/ldap.conf
+		fi
+
+		if [ "$HUMHUB_LDAP_CACERT" != "" ]; then
+			echo "Setting LDAP CACERT"
+			echo $HUMHUB_LDAP_CACERT > /etc/ssl/certs/cacert.crt
+			echo "TLS_CACERT  /etc/ssl/certs/cacert.crt" >> /etc/openldap/ldap.conf
+		fi
+		
 		php yii 'settings/set' 'base' 'mailer.systemEmailAddress' "${HUMHUB_MAILER_SYSTEM_EMAIL_ADDRESS}"
 		php yii 'settings/set' 'base' 'mailer.systemEmailName' "${HUMHUB_MAILER_SYSTEM_EMAIL_NAME}"
 		if [ "$HUMHUB_MAILER_TRANSPORT_TYPE" != "php" ]; then


### PR DESCRIPTION
Hi,

I added two enviroment variables for the issue #135:

- `HUMHUB_LDAP_CACERT` : Here you can insert your certificate and it will be written into the file `/etc/ssl/certs/cacert.crt` and then added to `/etc/openldap/ldap.conf` as `TLS_CACERT` 
example in docker compose:
```yaml
HUMHUB_LDAP_CACERT: |-
-----BEGIN CERTIFICATE-----
ahfoahofahofhlahfo...
-----END CERTIFICATE-----
```

- `HUMHUB_LDAP_SKIP_VERIFY`: if this is set to anything but 0 (zero is the standard value) it will write `TLS_REQCERT ALLOW` to  `/etc/openldap/ldap.conf`

I tested it locally and it works :)
