### PR TITLE
added thumbnail sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,19 +139,20 @@ HUMHUB_MAILER_ALLOW_SELF_SIGNED_CERTS []
 It is possible to configure HumHub LDAP authentication settings using the following environment variables:
 
 ```plaintext
-HUMHUB_LDAP_ENABLED            [0]
-HUMHUB_LDAP_HOSTNAME           []
-HUMHUB_LDAP_PORT               []
-HUMHUB_LDAP_ENCRYPTION         []
-HUMHUB_LDAP_USERNAME           []
-HUMHUB_LDAP_PASSWORD           []
-HUMHUB_LDAP_BASE_DN            []
-HUMHUB_LDAP_LOGIN_FILTER       []
-HUMHUB_LDAP_USER_FILTER        []
-HUMHUB_LDAP_USERNAME_ATTRIBUTE []
-HUMHUB_LDAP_EMAIL_ATTRIBUTE    []
-HUMHUB_LDAP_ID_ATTRIBUTE       []
-HUMHUB_LDAP_REFRESH_USERS      []
+HUMHUB_LDAP_ENABLED                               [0]
+HUMHUB_LDAP_HOSTNAME                              []
+HUMHUB_LDAP_PORT                                  []
+HUMHUB_LDAP_ENCRYPTION                            []
+HUMHUB_LDAP_USERNAME                              []
+HUMHUB_LDAP_PASSWORD                              []
+HUMHUB_LDAP_BASE_DN                               []
+HUMHUB_LDAP_LOGIN_FILTER                          []
+HUMHUB_LDAP_USER_FILTER                           []
+HUMHUB_LDAP_USERNAME_ATTRIBUTE                    []
+HUMHUB_LDAP_EMAIL_ATTRIBUTE                       []
+HUMHUB_LDAP_ID_ATTRIBUTE                          []
+HUMHUB_LDAP_REFRESH_USERS                         []
+HUMHUB_Advanced_LDAP_THUMBNAIL_SYNC_PROPERTY      [thumbnailphoto]
 ```
 
 ### PHP Config

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ HUMHUB_LDAP_USERNAME_ATTRIBUTE                    []
 HUMHUB_LDAP_EMAIL_ATTRIBUTE                       []
 HUMHUB_LDAP_ID_ATTRIBUTE                          []
 HUMHUB_LDAP_REFRESH_USERS                         []
-HUMHUB_Advanced_LDAP_THUMBNAIL_SYNC_PROPERTY      [thumbnailphoto]
+HUMHUB_ADVANCED_LDAP_THUMBNAIL_SYNC_PROPERTY      [thumbnailphoto]
 ```
 
 ### PHP Config

--- a/humhub/protected/config/common-factory.php
+++ b/humhub/protected/config/common-factory.php
@@ -20,6 +20,18 @@ $common = [
 ];
 
 /**
+ * LDAP Thumbnailsync for Advanced LDAP Module
+ * 
+ * @see https://www.humhub.com/de/marketplace/advanced-ldap/
+ */
+if (!empty(getenv('HUMHUB_Advanced_LDAP_THUMBNAIL_SYNC_PROPERTY'))) {
+    $common['components']['authClientCollection']['clients']['ldap'] = [
+        'class' => 'humhub\modules\advancedLdap\authclient\LdapAuth',
+        'profileImageAttribute' => getenv('HUMHUB_Advanced_LDAP_THUMBNAIL_SYNC_PROPERTY')
+    ];
+}
+
+/**
  * Redis configuration.
  *
  * @see https://docs.humhub.org/docs/admin/redis

--- a/humhub/protected/config/common-factory.php
+++ b/humhub/protected/config/common-factory.php
@@ -21,13 +21,13 @@ $common = [
 
 /**
  * LDAP Thumbnailsync for Advanced LDAP Module
- * 
+ *
  * @see https://www.humhub.com/de/marketplace/advanced-ldap/
  */
-if (!empty(getenv('HUMHUB_Advanced_LDAP_THUMBNAIL_SYNC_PROPERTY'))) {
+if (!empty(getenv('HUMHUB_ADVANCED_LDAP_THUMBNAIL_SYNC_PROPERTY'))) {
     $common['components']['authClientCollection']['clients']['ldap'] = [
         'class' => 'humhub\modules\advancedLdap\authclient\LdapAuth',
-        'profileImageAttribute' => getenv('HUMHUB_Advanced_LDAP_THUMBNAIL_SYNC_PROPERTY')
+        'profileImageAttribute' => getenv('HUMHUB_ADVANCED_LDAP_THUMBNAIL_SYNC_PROPERTY')
     ];
 }
 


### PR DESCRIPTION
Hi,

I needed some way to add 
```php
return [
    'components' => [
        'authClientCollection' => [
            'clients' => [
                'ldap' => [
                    'class' => 'humhub\modules\advancedLdap\authclient\LdapAuth',
                    'profileImageAttribute' => 'thumbnailphoto'
                ]
            ]
        ]
    ]
];
```
to `protected/config/common.php` so that I can use the Enterprise Module Advanced LDAP. I tested it locally and it works just fine.

So all you need to do to enable this ist set the `HUMHUB_LDAP_ENTERPRISE_THUMBNAIL_SYNC_PROPERTY` enviroment variable to the ldap property you want to use for the image sync ( in most cases 'thumbnailphoto')

Greetings