### PR TITLE
Absolute file URLs are wrong

### DIFF
--- a/humhub/protected/config/common-factory.php
+++ b/humhub/protected/config/common-factory.php
@@ -27,7 +27,7 @@ $common = [
 if (!empty(getenv('HUMHUB_PROTO'))) {
 	if (!empty(getenv('HUMHUB_HOST'))) {
 		$common['components']['urlManager']["hostInfo"] = getenv('HUMHUB_PROTO')."://".getenv('HUMHUB_HOST');
-		$common['components']['urlManager']["baseUrl"] = "/"
+		$common['components']['urlManager']["baseUrl"] = "/";
 	}
 }
 

--- a/humhub/protected/config/common-factory.php
+++ b/humhub/protected/config/common-factory.php
@@ -20,6 +20,18 @@ $common = [
 ];
 
 /**
+ * UrlManager
+ *
+ * @see https://github.com/humhub/humhub/issues/2220
+ */
+if (!empty(getenv('HUMHUB_PROTO'))) {
+	if (!empty(getenv('HUMHUB_HOST'))) {
+		$common['components']['urlManager']["hostInfo"] = getenv('HUMHUB_PROTO')."://".getenv('HUMHUB_HOST');
+		$common['components']['urlManager']["baseUrl"] = "/"
+	}
+}
+
+/**
  * LDAP Thumbnailsync for Advanced LDAP Module
  *
  * @see https://www.humhub.com/de/marketplace/advanced-ldap/


### PR DESCRIPTION
Added UrlManager HostInfo and BaseUrl corresponding to https://github.com/humhub/humhub/issues/2220

Problem is in short: Uploads are given a full url and not relative, so uploaded pictures are hosted via http instead of https if `HUMHUB_PROTO` is set to https. This results in a unsecure website warning.
