### PR TITLE
Feat/reverseproxy whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,9 @@ Following variables can be used to configure the embedded Nginx. The config-file
 ```plaintext
 NGINX_CLIENT_MAX_BODY_SIZE [10m]
 NGINX_KEEPALIVE_TIMEOUT    [65]
-HUMHUB_REVERSEPROXY_WHITELIST [127.0.0.1]
+HUMHUB_REVERSEPROXY_WHITELIST ["127.0.0.1;"]
 ```
+Hint: HUMHUB_REVERSEPROXY_WHITELIST must end with an ';'
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Following variables can be used to configure the embedded Nginx. The config-file
 ```plaintext
 NGINX_CLIENT_MAX_BODY_SIZE [10m]
 NGINX_KEEPALIVE_TIMEOUT    [65]
+HUMHUB_REVERSEPROXY_WHITELIST [127.0.0.1]
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ Following variables can be used to configure the embedded Nginx. The config-file
 ```plaintext
 NGINX_CLIENT_MAX_BODY_SIZE [10m]
 NGINX_KEEPALIVE_TIMEOUT    [65]
-HUMHUB_REVERSEPROXY_WHITELIST ["127.0.0.1;"]
+HUMHUB_REVERSEPROXY_WHITELIST ["127.0.0.1"]
 ```
-Hint: HUMHUB_REVERSEPROXY_WHITELIST must end with an ';'
+`HUMHUB_REVERSEPROXY_WHITELIST` allows access to the `/ping` endpoint for the given IP-Address. CIDR notation is supported.
 
 ## Contribution
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,9 +59,6 @@ HUMHUB_REDIS_HOSTNAME=${HUMHUB_REDIS_HOSTNAME}
 HUMHUB_REDIS_PORT=${HUMHUB_REDIS_PORT:-6379}
 HUMHUB_REDIS_PASSWORD=${HUMHUB_REDIS_PASSWORD}
 
-# Reverseproxy
-HUMHUB_REVERSEPROXY_WHITELIST=${HUMHUB_REVERSEPROXY_WHITELIST:-"127.0.0.1;"}
-
 wait_for_db() {
 	if [ "$WAIT_FOR_DB" = "false" ]; then
 		return 0
@@ -242,15 +239,6 @@ if [ "$HUMHUB_LDAP_CACERT" != "" ]; then
 	echo "$HUMHUB_LDAP_CACERT" > /etc/ssl/certs/cacert.crt
 	echo "TLS_CACERT  /etc/ssl/certs/cacert.crt" >> /etc/openldap/ldap.conf
 fi
-
-echo "Setting HUMHUB_REVERSEPROXY_WHITELIST"
-reverseproxyips=$(echo $HUMHUB_REVERSEPROXY_WHITELIST | tr ";" "\n")
-touch /etc/nginx/allowedips.conf
-for ip in $reverseproxyips
-do
-	echo "allow $ip;" >>  /etc/nginx/allowedips.conf
-	echo "Added $ip to Reverseproxy Whitelist"
-done
 
 if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null; then
 	echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,6 +59,9 @@ HUMHUB_REDIS_HOSTNAME=${HUMHUB_REDIS_HOSTNAME}
 HUMHUB_REDIS_PORT=${HUMHUB_REDIS_PORT:-6379}
 HUMHUB_REDIS_PASSWORD=${HUMHUB_REDIS_PASSWORD}
 
+# Reverseproxy
+HUMHUB_REVERSEPROXY_WHITELIST=${HUMHUB_REVERSEPROXY_WHITELIST:-"127.0.0.1;"}
+
 wait_for_db() {
 	if [ "$WAIT_FOR_DB" = "false" ]; then
 		return 0
@@ -239,6 +242,15 @@ if [ "$HUMHUB_LDAP_CACERT" != "" ]; then
 	echo "$HUMHUB_LDAP_CACERT" > /etc/ssl/certs/cacert.crt
 	echo "TLS_CACERT  /etc/ssl/certs/cacert.crt" >> /etc/openldap/ldap.conf
 fi
+
+echo "Setting HUMHUB_REVERSEPROXY_WHITELIST"
+reverseproxyips=$(echo $HUMHUB_REVERSEPROXY_WHITELIST | tr ";" "\n")
+touch /etc/nginx/allowedips.conf
+for ip in $reverseproxyips
+do
+	echo "allow $ip;" >>  /etc/nginx/allowedips.conf
+	echo "Added $ip to Reverseproxy Whitelist"
+done
 
 if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null; then
 	echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"

--- a/nginx/docker-entrypoint.d/70-nginx-allowedips.sh
+++ b/nginx/docker-entrypoint.d/70-nginx-allowedips.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Reverseproxy
+HUMHUB_REVERSEPROXY_WHITELIST=${HUMHUB_REVERSEPROXY_WHITELIST:-"127.0.0.1"}
+
+echo "Setting HUMHUB_REVERSEPROXY_WHITELIST"
+reverseproxyips=$(echo "$HUMHUB_REVERSEPROXY_WHITELIST" | tr ";" "\n")
+touch /etc/nginx/allowedips.conf
+for ip in $reverseproxyips
+do
+	echo "allow $ip;" >>  /etc/nginx/allowedips.conf
+	echo "Added $ip to Reverseproxy Whitelist"
+done

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -45,7 +45,8 @@ http {
         location ~ ^/(status|ping)$ {
             log_subrequest off;
             access_log off;
-            allow 127.0.0.1;
+            ## Add another config File, which is generated based upon enviroment variable HUMHUB_REVERSEPROXY_WHITELIST  ##
+            include allowedips.conf;
             deny all;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
Added Enviroment variable HUMHUB_REVERSEPROXY_WHITELIST for #177 

This Env variable is split by the charater `;`
Each IP is added in an extra file `/etc/nginx/allowedips.conf`  in the `docker-entrypoint.sh`
This file is included in the nginx.conf

