### PR TITLE
Feat(Search) environment variable for searchItemLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ HUMHUB_LDAP_REFRESH_USERS                         []
 HUMHUB_ADVANCED_LDAP_THUMBNAIL_SYNC_PROPERTY      [thumbnailphoto]
 ```
 
+### Search Config
+
+It is possible to configure HumHub search settings using the following environment variables:
+
+```plaintext
+HUMHUB_SEARCH_ITEM_LIMIT                               [2048]
+```
+
+`HUMHUB_SEARCH_ITEM_LIMIT` sets the `termsPerQueryLimit` of the Zend Lucene Search, it defaults to 2048.
+
 ### PHP Config
 
 It is also possible to change some php-config-settings. This comes in handy if you have to scale this container vertically.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,6 +25,7 @@ HUMHUB_CACHE_EXPIRE_TIME=${HUMHUB_CACHE_EXPIRE_TIME:-3600}
 HUMHUB_ANONYMOUS_REGISTRATION=${HUMHUB_ANONYMOUS_REGISTRATION:-1}
 HUMHUB_ALLOW_GUEST_ACCESS=${HUMHUB_ALLOW_GUEST_ACCESS:-0}
 HUMHUB_NEED_APPROVAL=${HUMHUB_NEED_APPROVAL:-0}
+HUMHUB_SEARCH_ITEM_LIMIT=${HUMHUB_SEARCH_ITEM_LIMIT:-2048}
 
 # LDAP Config
 HUMHUB_LDAP_ENABLED=${HUMHUB_LDAP_ENABLED:-0}
@@ -228,6 +229,10 @@ else
 	sed -i '/YII_ENV/s/^\/*//' /var/www/localhost/htdocs/index.php
 	echo >&3 "$0: debug enabled"
 fi
+
+echo "Setting search item limit to $HUMHUB_SEARCH_ITEM_LIMIT"
+sed -i  s/"public \$searchItemLimit = 2048;"/"public \$searchItemLimit = $HUMHUB_SEARCH_ITEM_LIMIT;"/ /var/www/localhost/htdocs/protected/humhub/modules/search/engine/ZendLuceneSearch.php
+
 
 if [ "$HUMHUB_LDAP_SKIP_VERIFY" != "0" ]; then
 	echo "Setting LDAP TLS SKIP VERIFY"


### PR DESCRIPTION
There is a Issue if a search query results in more than 2048 terms. To Fix this you can increase the search Item Limit in `/var/www/localhost/htdocs/protected/humhub/modules/search/engine/ZendLuceneSearch.php`

For this I added a env variable `HUMHUB_SEARCH_ITEM_LIMIT`