### PR TITLE
Version bump to fix CVE-2022-24865/ GHSA-2h35-f226-3f57

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,3 @@
-1.10.3 1.10 latest
-1.9.3 1.9 stable
+1.10.4 1.10 latest
+1.9.4 1.9 stable
 1.8.3 1.8 legacy


### PR DESCRIPTION
HumHub version 1.10.4 / 1.9.4 was released on 2022-04-19, fixing a critical security vulnerability

https://github.com/humhub/humhub/security/advisories/GHSA-2h35-f226-3f57