### PR TITLE
update latest to 1.11.4, stable to 1.10.5, legacy to 1.9.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.10", "1.9", "1.8"]
+        version: ["1.11", "1.10", "1.9"]
     steps:
     - uses: actions/checkout@v2
     - uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.10", "1.9", "1.8"]
+        version: ["1.11", "1.10", "1.9"]
         target: ["allinone", "nginx", "phponly"]
     steps:
     - uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.10", "1.9", "1.8"]
+        version: ["1.11", "1.10", "1.9"]
     steps:
     - uses: actions/checkout@v2
     - uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.10", "1.9", "1.8"]
+        version: ["1.11", "1.10", "1.9"]
     steps:
     - uses: actions/checkout@v2
     - uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.10", "1.9", "1.8"]
+        version: ["1.11", "1.10", "1.9"]
         target: ["allinone", "nginx", "phponly"]
     steps:
     - uses: actions/checkout@v2

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,3 @@
-1.10.4 1.10 latest
-1.9.4 1.9 stable
-1.8.3 1.8 legacy
+1.11.4 1.11 latest
+1.10.5 1.10 stable
+1.9.4 1.9 legacy


### PR DESCRIPTION
Hi Michael,

Here is a PR to update the latest/stable/legacy branches.

I tested the latest "all in one" image with success.

Thanks again for your job !
Best regards,
Jérémy