### PR TITLE
Add php extensions for OIDC (Authelia and Keycloak)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ARG RUNTIME_DEPS="\
     libintl \
     php81 \
     php81-apcu \
+    php81-bcmath \
     php81-ctype \
     php81-curl \
     php81-dom \
@@ -43,6 +44,7 @@ ARG RUNTIME_DEPS="\
     php81-fileinfo \
     php81-fpm \
     php81-gd \
+    php81-gmp \
     php81-iconv \
     php81-intl \
     php81-json \

--- a/versions.txt
+++ b/versions.txt
@@ -1,3 +1,3 @@
-1.15.2 1.15 latest
+1.15.4 1.15 latest
 1.14.5 1.14 stable
 1.13.2 1.13 legacy


### PR DESCRIPTION
Hi Michael,

Can you add these php extensions needed for Openid ?

They are required by these two Humhub modules:

https://github.com/cuzy-app/humhub-modules-auth-keycloak
https://github.com/jvies/humhub-modules-auth-authelia

I can move out the version update if you want.