### PR TITLE
Don't rebuilt search index after update anymore

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -98,7 +98,6 @@ if [ -f "/var/www/localhost/htdocs/protected/config/dynamic.php" ]; then
 	if [ "$INSTALL_VERSION" != "$SOURCE_VERSION" ]; then
 		echo >&3 "$0: Updating from version $INSTALL_VERSION to $SOURCE_VERSION"
 		php yii migrate/up --includeModuleMigrations=1 --interactive=0
-		php yii search/rebuild
 		cp -v /usr/src/humhub/.version /var/www/localhost/htdocs/protected/config/.version
 	fi
 else


### PR DESCRIPTION
With version 1.16 the search index is rebuilt automatically after updates: https://docs.humhub.org/docs/admin/updating-migration#116

This also fixes an issue with the 1.16 version of the image: https://github.com/mriedmann/humhub-docker/issues/356#issuecomment-2244573386